### PR TITLE
stable f0 estimation

### DIFF
--- a/inference/infer_tool.py
+++ b/inference/infer_tool.py
@@ -92,13 +92,13 @@ def resize2d_f0(x, target_len):
 def get_f0(x, p_len,f0_up_key=0):
 
     time_step = 160 / 16000 * 1000
-    f0_min = 50
+    f0_min = 75
     f0_max = 1100
     f0_mel_min = 1127 * np.log(1 + f0_min / 700)
     f0_mel_max = 1127 * np.log(1 + f0_max / 700)
 
-    f0 = parselmouth.Sound(x, 16000).to_pitch_ac(
-        time_step=time_step / 1000, voicing_threshold=0.6,
+    f0 = parselmouth.Sound(x, 16000).to_pitch_cc(
+        time_step=time_step / 1000, voicing_threshold=0.3,
         pitch_floor=f0_min, pitch_ceiling=f0_max).selected_array['frequency']
     if len(f0) > p_len:
         f0 = f0[:p_len]

--- a/inference/infer_tool_grad.py
+++ b/inference/infer_tool_grad.py
@@ -31,13 +31,13 @@ def resize2d_f0(x, target_len):
 def get_f0(x, p_len,f0_up_key=0):
 
     time_step = 160 / 16000 * 1000
-    f0_min = 50
+    f0_min = 75
     f0_max = 1100
     f0_mel_min = 1127 * np.log(1 + f0_min / 700)
     f0_mel_max = 1127 * np.log(1 + f0_max / 700)
 
-    f0 = parselmouth.Sound(x, 16000).to_pitch_ac(
-        time_step=time_step / 1000, voicing_threshold=0.6,
+    f0 = parselmouth.Sound(x, 16000).to_pitch_cc(
+        time_step=time_step / 1000, voicing_threshold=0.3,
         pitch_floor=f0_min, pitch_ceiling=f0_max).selected_array['frequency']
 
     pad_size=(p_len - len(f0) + 1) // 2


### PR DESCRIPTION
cc results in more stable f0 estimation than ac at these sorts of time steps. doing this can cause audible pitch windowing, which is mitigated by leaving the hubert f0 method the same. the net result is significantly improved inference quality with little downside

Bad case source recording:
Stock:
[The BabelFish](https://u.smutty.horse/mlmtvsdbwzn.mp3)
Tuned:
[The BabelFish](https://u.smutty.horse/mlmtvscpxdw.mp3)